### PR TITLE
update  meta-openembedded git  repo clone url

### DIFF
--- a/tools/meta-bake/n6000/layers.yaml
+++ b/tools/meta-bake/n6000/layers.yaml
@@ -20,7 +20,7 @@ repos:
     keep: true
     add_layers: true
   - name: meta-openembedded
-    url: git://git.openembedded.org/meta-openembedded.git
+    url: https://github.com/openembedded/meta-openembedded.git
     branch: hardknott
     add_layers:
       - meta-oe


### PR DESCRIPTION
 update  git://git.openembedded.org/meta-openembedded.git  to
 https://github.com/openembedded/meta-openembedded.git

Signed-off-by: anandaravuri <ananda.ravuri@intel.com>