### PR TITLE
Add Vendor Authorized Boot support to HPS boot image

### DIFF
--- a/tools/meta-bake/meta-bake.py
+++ b/tools/meta-bake/meta-bake.py
@@ -302,7 +302,7 @@ class bitbaker:
         quartus_path = os.path.abspath('{}/{}'.format(args.quartus,
                                                       "bin/quartus_sign"))
         if not os.path.exists(quartus_path):
-            print(" Invalid quartu_path:", quartus_path)
+            print(" Invalid quartus_path:", quartus_path)
             return -1
         print(" quartus_path:", quartus_path)
 
@@ -336,29 +336,26 @@ class bitbaker:
 
             # delete unsigned_cert.cert
             unsigned_cert_path = build_vab + "/" + "unsigned_cert.ccert"
-            print("unsigned_cert_patht:", unsigned_cert_path)
+            print("unsigned_cert_path:", unsigned_cert_path)
             if os.path.exists(unsigned_cert_path):
                 os.remove(unsigned_cert_path)
 
             # create unsigned_cert.ccert
-            p1 = subprocess.Popen(args=[fcs_prepare,
-                                  '--hps_cert', uboot_binary[i], '-v'], cwd=build_vab)
-            p1.wait()
+            p1 = subprocess.check_call(args=[fcs_prepare,
+                                       '--hps_cert', uboot_binary[i], '-v'], cwd=build_vab)
 
             # create signed cert
             signed_cert = 'signed_cert{}.ccert'.format(uboot_binary[i])
             # print(" signed_cert:",signed_cert)
             signed_cert_path = build_vab + "/" + signed_cert
-            p1 = subprocess.Popen(args=[quartus_path, '--family=agilex',
-                                  '--operation=SIGN', str('--qky=' + root_public_qky),
-                                  str('--pem=' + root_private_pem), unsigned_cert_path,
-                                  signed_cert], cwd=build_vab)
-            p1.wait()
+            p1 = subprocess.check_call(args=[quartus_path, '--family=agilex',
+                                       '--operation=SIGN', str('--qky=' + root_public_qky),
+                                       str('--pem=' + root_private_pem), unsigned_cert_path,
+                                       signed_cert], cwd=build_vab)
 
             # Sign binary
-            p1 = subprocess.Popen(args=[fcs_prepare, '--finish', signed_cert_path,
-                                  '--imagefile', uboot_binary[i]], cwd=build_vab)
-            p1.wait()
+            p1 = subprocess.check_call(args=[fcs_prepare, '--finish', signed_cert_path,
+                                       '--imagefile', uboot_binary[i]], cwd=build_vab)
 
             signed_bin = 'signed-{}'.format(uboot_binary[i])
             # print(" signed_bin:",signed_bin)
@@ -376,21 +373,21 @@ class bitbaker:
 
         # Build VAB enabled uboot
         print("uboot_vab:", uboot_vab)
-        ret_value = subprocess.call("make clean && make mrproper", cwd=uboot_vab, shell=True)
+        ret_value = subprocess.run(["make clean && make mrproper"], cwd=uboot_vab, shell=True)
         if not ret_value:
             print("Failed to make clean uboot soruce code ", ret_value)
 
-        ret_value = subprocess.call("make socfpga_agilex_n6000_vab_defconfig", cwd=uboot_vab, shell=True)
+        ret_value = subprocess.run(["make socfpga_agilex_n6000_vab_defconfig"], cwd=uboot_vab, shell=True)
         if not ret_value:
             print("Failed to make socfpga_agilex_n6000_vab_defconfig ", ret_value)
 
-        ret_value = subprocess.call("make -j", cwd=uboot_vab, shell=True)
+        ret_value = subprocess.run(["make -j"], cwd=uboot_vab, shell=True)
         if not ret_value:
             print("Failed to make uboot ", ret_value)
 
         # print("images_dir ",images_dir)
         uboot_userkey_vab = os.path.abspath('{}/{}'.format(images_dir,
-                                                           "u-boot-userkey-vab.itb"))
+                                                           "u-boot-vab.itb"))
 
         uboot_stl_vab = os.path.abspath('{}/{}'.format(images_dir,
                                                        "u-boot-spl-dtb-vab.hex"))

--- a/tools/meta-bake/n6000/layers.yaml
+++ b/tools/meta-bake/n6000/layers.yaml
@@ -2,6 +2,11 @@ machine: agilex
 image: n6000
 target: n6000-image-minimal
 fit: true
+uboot-binary: [bl31.bin, u-boot-nodtb.bin, u-boot.dtb, linux.dtb, rootfs.cpio, Image]
+root-public-qky: userkey_root_public.qky
+root-private-pem: userkey_root_private.pem
+root-public-pem: userkey_root_public.pem
+
 repos:
   - name: poky
     url: https://git.yoctoproject.org/git/poky.git
@@ -26,6 +31,10 @@ repos:
       - meta-oe
       - meta-networking
       - meta-python
+  - name: fcs_prepare
+    url: https://github.com/altera-opensource/fcs_apps.git
+    branch: fcs_prepare
+
 ingredients:
   linux:
     name: linux-socfpga

--- a/tools/meta-bake/n6000/quick-start-n6000.md
+++ b/tools/meta-bake/n6000/quick-start-n6000.md
@@ -58,6 +58,30 @@ Image  linux.dtb  rootfs.cpio
 > make
 ```
 
+## Vendor Authorized Boot ##
+The Intel Agilex Soc Secure supports end-to-end authenticated boot flow, from device power on until the Linux kernel is loaded
+
+### VAB Build Setup ###
+
+* Install Quartus on Build System
+* Creating User Keys using uartus_sign
+``` 
+quartus_sign --family=agilex --operation=make_private_pem --curve=secp384r1 --no_passphrase  userkey_root_private.pem
+quartus_sign --family=agilex --operation=make_public_pem  userkey_root_private.pem  userkey_root_public.pem
+quartus_sign --family=agilex --operation=make_root userkey_root_public.pem  userkey_root_public.qky 
+```
+
+
+* Copy user keys to folder meta-opae-fpga/tools/meta-bake/n6000/vab/
+* Run VAB enabled build command signs Images with user keys and generates VAB enabled Images 
+
+ Example VABBuild Commad
+``` 
+./meta-opae-fpga/tools/meta-bake/meta-bake.py build_vab --conf /home/user/meta-opae-fpga/tools/meta-bake/n6000/layers.yaml --no-cleanup --vab --quartus /home/user/intelFPGA_pro/22.1/qprogrammer/quartus/
+```
+
+* VAB images are generated u-boot-vab.itb and  u-boot-spl-dtb-vab.hex in folder Build folder/agilex-n6000-images
+
 ## References ##
 
 ### layers.yaml ###

--- a/tools/meta-bake/n6000/quick-start-n6000.md
+++ b/tools/meta-bake/n6000/quick-start-n6000.md
@@ -73,11 +73,21 @@ quartus_sign --family=agilex --operation=make_root userkey_root_public.pem  user
 
 
 * Copy user keys to folder meta-opae-fpga/tools/meta-bake/n6000/vab/
-* Run VAB enabled build command signs Images with user keys and generates VAB enabled Images 
+* Setup ARM cross compiler environment
 
- Example VABBuild Commad
+Example ARM compiler environment
+```
+wget https://developer.arm.com/-/media/Files/downloads/gnu-a/10.2-2020.11/binrel/gcc-arm-10.2-2020.11-x86_64-aarch64-none-linux-gnu.tar.xz
+tar xf gcc-arm-10.2-2020.11-x86_64-aarch64-none-linux-gnu.tar.xz
+rm gcc-arm-10.2-2020.11-x86_64-aarch64-none-linux-gnu.tar.xz
+export CROSS_COMPILE=`pwd`/gcc-arm-10.2-2020.11-x86_64-aarch64-none-linux-gnu/bin/aarch64-none-linux-gnu-
+export ARCH=arm64
+```
+* Run VAB enabled build command to sign Images with user keys and generate VAB enabled Images. 
+
+Example VAB Enabled Build Command
 ``` 
-./meta-opae-fpga/tools/meta-bake/meta-bake.py build_vab --conf /home/user/meta-opae-fpga/tools/meta-bake/n6000/layers.yaml --no-cleanup --vab --quartus /home/user/intelFPGA_pro/22.1/qprogrammer/quartus/
+./meta-opae-fpga/tools/meta-bake/meta-bake.py build_vab --conf /home/user/meta-opae-fpga/tools/meta-bake/n6000/layers.yaml  --vab --quartus /home/user/intelFPGA_pro/22.1/qprogrammer/quartus/
 ```
 
 * VAB images are generated u-boot-vab.itb and  u-boot-spl-dtb-vab.hex in folder Build folder/agilex-n6000-images


### PR DESCRIPTION
       - add  --vab and  --quartus  commands to make bake
       - copy userkey_root_public.qky, userkey_root_private.pem, userkey_root_public.pem certs to VAB folder
       - VAB Make bake build process steps
            - Quartus _sign tool signs UBoot and Linux images (bl31.bin, u-boot-nodtb.bin, u-boot.dtb, linux.dtb, rootfs.cpio, Image)
            - Creates Vendor Authorized Boot HPS image  u-boot-userkey-vab.itb and  Hex file u-boot-spl-dtb-vab.hex